### PR TITLE
Add version string

### DIFF
--- a/middleware_gcs.py
+++ b/middleware_gcs.py
@@ -21,6 +21,7 @@ from OpenSSL.crypto import sign
 from urlparse import urlparse
 from urllib import quote_plus
 
+__version__ = '1.0'
 #Our json keystore file
 JSON_FILE = 'gcs.json'
 JSON_FILE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), JSON_FILE))


### PR DESCRIPTION
Adding a version string will allow the various reporting tools that hook in with Munki to collect installed versions accurately without having to rely on package strings. See munkireport/munkireport-php#737 for the MR-PHP implementation - essentially, import the middleware module and do `middleware_gcs.version` to return the string.